### PR TITLE
Fix the number of analyzed functions

### DIFF
--- a/shellmetrics
+++ b/shellmetrics
@@ -276,7 +276,7 @@ default_report() {
   echo "=============================================================================="
   echo "  LLOC  CCN  Location"
   echo "------------------------------------------------------------------------------"
-  file_count=0 func_count=0
+  file_count=0 func_count_all=0
   array lloc_total ccn_total func_count file nloc_total
   array lines_total comment_total blank_total
   while IFS=" " read -r lloc ccn func file; do
@@ -298,10 +298,11 @@ default_report() {
     lloc_total=$((lloc_total + lloc))
     ccn_total=$((ccn_total + ccn))
     func_count=$((func_count + 1))
+    func_count_all=$((func_count_all + 1))
     printf '%6d %4d  %s %s\n' "$lloc" "$ccn" "$func" "$file"
   done
   echo "------------------------------------------------------------------------------"
-  set -- "$file_count" "$func_count" "$SHELL_VERSION"
+  set -- "$file_count" "$func_count_all" "$SHELL_VERSION"
   printf " %d file(s), %d function(s) analyzed. [%s]\n" "$@"
 
   echo

--- a/spec/shellmetrics_spec.sh
+++ b/spec/shellmetrics_spec.sh
@@ -406,7 +406,7 @@ Describe "default_report()"
     #|     7   29  func7:70 script2.sh
     #|     8   31  func8:80 script2.sh
     #|------------------------------------------------------------------------------
-    #| 2 file(s), 5 function(s) analyzed. [shell-version]
+    #| 2 file(s), 8 function(s) analyzed. [shell-version]
     #|
     #|==============================================================================
     #| NLOC    NLOC  LLOC    LLOC    CCN Func File (lines:comment:blank)


### PR DESCRIPTION
@ko1nksm 以下で表示される "関数の数" が、"最後のファイルの関数の数" になっていたのを "全体の関数の数" に修正

```
==============================================================================
  LLOC  CCN  Location
------------------------------------------------------------------------------
中略
------------------------------------------------------------------------------
 14 file(s), 16 function(s) analyzed. [bash 5.0.11(1)-release]
```
